### PR TITLE
Fix Vercel build: add missing depschore: add missing genkit and opentelemetry deps for Vercelchore: add…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@genkit-ai/firebase": "^1.1.2",
     "@genkit-ai/googleai": "^1.1.2",
     "@hookform/resolvers": "^4.1.3",
+    "@opentelemetry/exporter-jaeger": "^1.17.0",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",


### PR DESCRIPTION
This PR fixes the Vercel build errors by adding the missing dependencies:

- `@genkit-ai/firebase`: ^1.1.2
- `@opentelemetry/exporter-jaeger`: ^1.17.0

These dependencies were causing module resolution errors during the build process, preventing successful deployment to Vercel.… missing genkit and opentelemetry deps for VercelUpdate package.json